### PR TITLE
Add password field to ssh and sftp sessions

### DIFF
--- a/mobaxterm/models/session.py
+++ b/mobaxterm/models/session.py
@@ -8,6 +8,7 @@ class Session:
     host: str
     port: int
     username: Optional[str] = None
+    password: Optional[str] = None
     terminal_settings: bool = False
     network_settings: bool = False
     folder: Optional[str] = None 
@@ -29,6 +30,7 @@ class Session:
             'host': self.host,
             'port': self.port,
             'username': self.username,
+            'password': self.password,
             'terminal_settings': self.terminal_settings,
             'network_settings': self.network_settings,
             'bookmark_settings': self.bookmark_settings,
@@ -42,6 +44,7 @@ class Session:
             host=data['host'],
             port=data['port'],
             username=data['username'],
+            password=data.get('password'),
             terminal_settings=data.get('terminal_settings', False),
             network_settings=data.get('network_settings', False),
             bookmark_settings=data.get('bookmark_settings', False),

--- a/mobaxterm/ui/main_window.py
+++ b/mobaxterm/ui/main_window.py
@@ -32,7 +32,8 @@ class SSHThread(QThread):
         self.ssh_client.connect(
             host=self.session.host,
             port=self.session.port,
-            username=self.session.username
+            username=self.session.username,
+            password=self.session.password
         )
 
 class MobaXtermClone(QMainWindow):
@@ -359,6 +360,7 @@ class MobaXtermClone(QMainWindow):
                 host=new_name,
                 port=session.port,
                 username=session.username,
+                password=session.password,
                 folder=session.folder,
                 terminal_settings=session.terminal_settings,
                 network_settings=session.network_settings,

--- a/mobaxterm/ui/session_dialog.py
+++ b/mobaxterm/ui/session_dialog.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton, 
                              QLabel, QLineEdit, QCheckBox, QSpinBox, QGroupBox,
-                             QDialogButtonBox, QGridLayout, QStackedWidget, QWidget, QComboBox)
+                             QDialogButtonBox, QGridLayout, QStackedWidget, QWidget, QComboBox, QInputDialog)
 from PyQt5.QtCore import Qt
 from ..models.session import Session
 
@@ -217,25 +217,35 @@ class SessionDialog(QDialog):
         self.ssh_username_input.setEnabled(False)
         basic_layout.addWidget(self.ssh_username_input, 2, 1)
         
-        # Row 3: Port checkbox
-        self.ssh_port_check = QCheckBox("Custom port")
-        basic_layout.addWidget(self.ssh_port_check, 3, 0, 1, 2)
+        # Row 3: Password label and input
+        password_label = QLabel("Password:")
+        password_label.setMinimumWidth(100)
+        basic_layout.addWidget(password_label, 3, 0, Qt.AlignRight)
         
-        # Row 4: Port label and input
+        self.ssh_password_input = QLineEdit()
+        self.ssh_password_input.setEchoMode(QLineEdit.Password)
+        self.ssh_password_input.setPlaceholderText("password")
+        basic_layout.addWidget(self.ssh_password_input, 3, 1)
+        
+        # Row 4: Port checkbox
+        self.ssh_port_check = QCheckBox("Custom port")
+        basic_layout.addWidget(self.ssh_port_check, 4, 0, 1, 2)
+        
+        # Row 5: Port label and input
         port_label = QLabel("Port:")
         port_label.setMinimumWidth(100)
-        basic_layout.addWidget(port_label, 4, 0, Qt.AlignRight)
+        basic_layout.addWidget(port_label, 5, 0, Qt.AlignRight)
         
         self.ssh_port_input = QSpinBox()
         self.ssh_port_input.setRange(1, 65535)
         self.ssh_port_input.setValue(22)
         self.ssh_port_input.setEnabled(False)
-        basic_layout.addWidget(self.ssh_port_input, 4, 1)
+        basic_layout.addWidget(self.ssh_port_input, 5, 1)
         
-        # Row 5: Folder label and combo
+        # Row 6: Folder label and combo
         folder_label = QLabel("Folder:")
         folder_label.setMinimumWidth(100)
-        basic_layout.addWidget(folder_label, 5, 0, Qt.AlignRight)
+        basic_layout.addWidget(folder_label, 6, 0, Qt.AlignRight)
         
         self.folder_combo = QComboBox()
         self.folder_combo.addItem("(No folder)", None)
@@ -247,7 +257,7 @@ class SessionDialog(QDialog):
                 self.folder_combo.addItem(folder, folder)
         
         self.folder_combo.addItem("+ Create new folder...", "new")
-        basic_layout.addWidget(self.folder_combo, 5, 1)
+        basic_layout.addWidget(self.folder_combo, 6, 1)
         
         layout.addWidget(basic_group)
         
@@ -328,20 +338,30 @@ class SessionDialog(QDialog):
         self.sftp_username_input.setPlaceholderText("username")
         basic_layout.addWidget(self.sftp_username_input, 1, 1)
         
-        # Row 2: Port
+        # Row 2: Password
+        password_label = QLabel("Password:")
+        password_label.setMinimumWidth(100)
+        basic_layout.addWidget(password_label, 2, 0, Qt.AlignRight)
+        
+        self.sftp_password_input = QLineEdit()
+        self.sftp_password_input.setEchoMode(QLineEdit.Password)
+        self.sftp_password_input.setPlaceholderText("password")
+        basic_layout.addWidget(self.sftp_password_input, 2, 1)
+        
+        # Row 3: Port
         port_label = QLabel("Port:")
         port_label.setMinimumWidth(100)
-        basic_layout.addWidget(port_label, 2, 0, Qt.AlignRight)
+        basic_layout.addWidget(port_label, 3, 0, Qt.AlignRight)
         
         self.sftp_port_input = QSpinBox()
         self.sftp_port_input.setRange(1, 65535)
         self.sftp_port_input.setValue(22)
-        basic_layout.addWidget(self.sftp_port_input, 2, 1)
+        basic_layout.addWidget(self.sftp_port_input, 3, 1)
         
-        # Row 3: Folder
+        # Row 4: Folder
         folder_label = QLabel("Folder:")
         folder_label.setMinimumWidth(100)
-        basic_layout.addWidget(folder_label, 3, 0, Qt.AlignRight)
+        basic_layout.addWidget(folder_label, 4, 0, Qt.AlignRight)
         
         self.sftp_folder_combo = QComboBox()
         self.sftp_folder_combo.addItem("(No folder)", None)
@@ -352,7 +372,7 @@ class SessionDialog(QDialog):
                 self.sftp_folder_combo.addItem(folder, folder)
         
         self.sftp_folder_combo.addItem("+ Create new folder...", "new")
-        basic_layout.addWidget(self.sftp_folder_combo, 3, 1)
+        basic_layout.addWidget(self.sftp_folder_combo, 4, 1)
         
         layout.addWidget(basic_group)
         
@@ -418,6 +438,9 @@ class SessionDialog(QDialog):
                 self.ssh_username_input.setText(session.username)
                 self.ssh_username_input.setEnabled(True)
             
+            if session.password:
+                self.ssh_password_input.setText(session.password)
+            
             if session.port != 22:
                 self.ssh_port_check.setChecked(True)
                 self.ssh_port_input.setValue(session.port)
@@ -437,6 +460,8 @@ class SessionDialog(QDialog):
             self.sftp_host_input.setText(session.host)
             self.sftp_username_input.setText(session.username or "")
             self.sftp_port_input.setValue(session.port)
+            if session.password:
+                self.sftp_password_input.setText(session.password)
             
             if session.folder:
                 index = self.sftp_folder_combo.findData(session.folder)
@@ -452,6 +477,7 @@ class SessionDialog(QDialog):
                 host=self.ssh_host_input.text(),
                 port=self.ssh_port_input.value() if self.ssh_port_check.isChecked() else 22,
                 username=self.ssh_username_input.text() if self.ssh_username_check.isChecked() else None,
+                password=self.ssh_password_input.text() or None,
                 terminal_settings=self.ssh_terminal_check.isChecked(),
                 network_settings=self.ssh_network_check.isChecked(),
                 bookmark_settings=self.ssh_bookmark_check.isChecked()
@@ -464,6 +490,7 @@ class SessionDialog(QDialog):
                 host=self.sftp_host_input.text(),
                 port=self.sftp_port_input.value(),
                 username=self.sftp_username_input.text(),
+                password=self.sftp_password_input.text() if hasattr(self, 'sftp_password_input') else None,
                 bookmark_settings=self.sftp_bookmark_check.isChecked()
             )
             session.folder = self.sftp_folder_combo.currentData()


### PR DESCRIPTION
Add a password field to SSH and SFTP sessions to allow users to store and use passwords for connections.

---
<a href="https://cursor.com/background-agent?bcId=bc-52ceb220-b0f3-43e2-b415-cb43f7efee15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52ceb220-b0f3-43e2-b415-cb43f7efee15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

