### PR TITLE
Настроить приглашение терминала и сочетания клавиш

### DIFF
--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -155,7 +155,7 @@ class SSHClient(QObject):
             self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi\n")
             time.sleep(0.01)
             # 5) prompt and locale
-            self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1; printf ''\n")
+            self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1\n")
             time.sleep(0.01)
             self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1\n")
             time.sleep(0.01)

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -110,14 +110,20 @@ class SSHClient(QObject):
     def configure_remote_environment(self):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
-            self.shell.send(
-                "stty -echo 2>/dev/null; "
-                "stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null; "
-                "stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
-                "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null; "
-                "export PS1='[\\u@\\h \\w]\\$ '; export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null; "
-                "stty echo 2>/dev/null\n"
-            )
+            # Stepwise to let -echo take effect before further commands are echoed
+            self.shell.send("stty -echo 2>/dev/null\n")
+            time.sleep(0.05)
+            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
+            time.sleep(0.02)
+            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
+            time.sleep(0.02)
+            self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")
+            time.sleep(0.02)
+            self.shell.send("export PS1='[\\u@\\h \\w]\\$ '\n")
+            time.sleep(0.02)
+            self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null\n")
+            time.sleep(0.02)
+            self.shell.send("stty echo 2>/dev/null\n")
         except Exception:
             pass
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -126,15 +126,15 @@ class SSHClient(QObject):
         try:
             # Run configuration in a single compound command to avoid multiple prompts
             cmd = (
-                'OLD_PS1="$PS1"; OLD_PC="$PROMPT_COMMAND"; '
-                'stty -echo 2>/dev/null; '
-                'PS1=; PROMPT_COMMAND=; '
-                'stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null; '
-                'stty icanon icrnl -inlcr -igncr onlcr 2>/dev/null; '
-                'if [ -n "$BASH_VERSION" ]; then bind '\''set enable-bracketed-paste off'\'' >/dev/null 2>&1; fi; '
-                'export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1; '
-                'stty echo 2>/dev/null; '
-                'PS1="$OLD_PS1"; PROMPT_COMMAND="$OLD_PC"\n'
+                "OLD_PS1=\"$PS1\"; OLD_PC=\"$PROMPT_COMMAND\"; "
+                "stty -echo 2>/dev/null; "
+                "PS1=; PROMPT_COMMAND=; "
+                "stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null; "
+                "stty icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
+                "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi; "
+                "export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1; "
+                "stty echo 2>/dev/null; "
+                "PS1=\"$OLD_PS1\"; PROMPT_COMMAND=\"$OLD_PC\"\n"
             )
             self.shell.send(cmd)
         except Exception:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -133,6 +133,11 @@ class SSHClient(QObject):
             cmd_ps1_empty = ":; PS1=\n"
             self._suppress_bytes += cmd_ps1_empty.encode('utf-8')
             self.shell.send(cmd_ps1_empty)
+            # Clear the currently printed default prompt line
+            try:
+                self.shell.send("\r\x1b[K")
+            except Exception:
+                pass
             time.sleep(0.01)
             # 3) keyboard/erase and flow control (with echo still OFF)
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
@@ -148,8 +153,14 @@ class SSHClient(QObject):
             time.sleep(0.01)
             self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1\n")
             time.sleep(0.01)
-            # 7) finally re-enable echo
+            # 7) finally re-enable echo and force redraw of prompt once
             self.shell.send("stty echo 2>/dev/null\n")
+            time.sleep(0.01)
+            try:
+                # Newline to make bash print the prompt with new PS1
+                self.shell.send("\r\n")
+            except Exception:
+                pass
         except Exception:
             pass
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -117,7 +117,8 @@ class SSHClient(QObject):
         try:
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
             # Ensure canonical mode and echo; prefer ERASE=^H for compatibility
-            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^H 2>/dev/null\n")
+            # Prefer ERASE=^? (DEL); if не поддерживается, bash всё равно примет Ctrl+H из UI
+            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
             self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
             # Disable bracketed paste to avoid \x1b[?2004h noise
             # Use bash builtins when available; ignore errors on other shells

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -111,7 +111,8 @@ class SSHClient(QObject):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
             # Stepwise to let -echo take effect before further commands are echoed
-            self.shell.send("stty -echo 2>/dev/null\n")
+            # Turn off echo and hide prompt while configuring; clear last echoed line
+            self.shell.send("stty -echo 2>/dev/null; PS1=; printf '\033[1A\r\033[K'\n")
             time.sleep(0.05)
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
             time.sleep(0.02)

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -88,7 +88,10 @@ class SSHClient(QObject):
                     if not data_bytes:
                         time.sleep(0.02)
                         continue
-                    data = data_bytes.decode('utf-8', errors='ignore')
+                    try:
+                        data = data_bytes.decode('utf-8')
+                    except UnicodeDecodeError:
+                        data = data_bytes.decode('utf-8', errors='ignore')
                     if data:
                         self.output_received.emit(data)
                 else:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -109,6 +109,8 @@ class SSHClient(QObject):
         try:
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D 2>/dev/null\n")
+            # Disable bracketed paste to avoid \x1b[?2004h noise
+            self.shell.send("bind 'set enable-bracketed-paste off' 2>/dev/null\n")
             # Set a simple, portable prompt. Works in bash/sh; \u,\h,\w are bash, but many servers use bash.
             # If not bash, this will be ignored harmlessly.
             self.shell.send("export PS1='[\\u@\\h \\w]\\$ '\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -148,8 +148,17 @@ class SSHClient(QObject):
             time.sleep(0.01)
             self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1\n")
             time.sleep(0.01)
-            # 7) finally re-enable echo (do not send extra CR/LF)
+            # 7) clear current line, re-enable echo, then request exactly one new prompt
+            try:
+                # Clear any residual prompt line while echo is still off
+                self.shell.send("\x1b[2K\r")
+                time.sleep(0.005)
+            except Exception:
+                pass
             self.shell.send("stty echo 2>/dev/null\n")
+            time.sleep(0.01)
+            # Ask shell to render one new prompt
+            self.shell.send("\n")
         except Exception:
             pass
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -116,9 +116,9 @@ class SSHClient(QObject):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
-            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null\n")
-            # Ensure canonical mode with echo and CR to NL mapping; set erase to DEL
-            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr erase ^? 2>/dev/null\n")
+            # Ensure canonical mode and echo; prefer ERASE=^H for compatibility
+            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^H 2>/dev/null\n")
+            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
             # Disable bracketed paste to avoid \x1b[?2004h noise
             # Use bash builtins when available; ignore errors on other shells
             self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -124,7 +124,7 @@ class SSHClient(QObject):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
             # First: turn echo OFF so next commands are not echoed by the PTY
-            cmd0 = "stty -echo 2>/dev/null\r"
+            cmd0 = "stty -echo 2>/dev/null\n"
             self._suppress_bytes += cmd0.encode('utf-8')
             self.shell.send(cmd0)
             time.sleep(0.02)
@@ -136,7 +136,7 @@ class SSHClient(QObject):
                 "stty icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
                 "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi; "
                 "export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1; "
-                "stty echo 2>/dev/null\r"
+                "stty echo 2>/dev/null\n"
             )
             self.shell.send(cmd)
         except Exception:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -46,7 +46,7 @@ class SSHClient(QObject):
             self.is_connected = True
             # Allocate interactive PTY shell with colors
             self.shell = self.client.invoke_shell(term='xterm-256color')
-            self.shell.settimeout(0.1)
+            self.shell.settimeout(0.0)
             
             # Start reading thread
             self.read_thread = threading.Thread(target=self.read_output)
@@ -78,15 +78,15 @@ class SSHClient(QObject):
         while self.is_connected:
             try:
                 if self.shell and self.shell.recv_ready():
-                    data_bytes = self.shell.recv(4096)
+                    data_bytes = self.shell.recv(32768)
                     if not data_bytes:
-                        time.sleep(0.05)
+                        time.sleep(0.02)
                         continue
                     data = data_bytes.decode('utf-8', errors='ignore')
                     if data:
                         self.output_received.emit(data)
                 else:
-                    time.sleep(0.05)
+                    time.sleep(0.02)
             except Exception:
                 time.sleep(0.1)
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -60,8 +60,7 @@ class SSHClient(QObject):
             # Emit status to UI only (do not write to terminal widget)
             self.connection_status.emit(True, f"✅ Connected to {host}:{port}")
 
-            # Give the server a brief moment to print MOTD/Last login, then configure
-            time.sleep(0.3)
+            # Configure immediately to avoid extra prompts
             self.configure_remote_environment()
             
         except paramiko.AuthenticationException:
@@ -125,7 +124,7 @@ class SSHClient(QObject):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
             # First: turn echo OFF so next commands are not echoed by the PTY
-            cmd0 = "stty -echo 2>/dev/null\n"
+            cmd0 = "stty -echo 2>/dev/null\r"
             self._suppress_bytes += cmd0.encode('utf-8')
             self.shell.send(cmd0)
             time.sleep(0.02)
@@ -137,7 +136,7 @@ class SSHClient(QObject):
                 "stty icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
                 "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi; "
                 "export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1; "
-                "stty echo 2>/dev/null\n"
+                "stty echo 2>/dev/null\r"
             )
             self.shell.send(cmd)
         except Exception:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -129,11 +129,7 @@ class SSHClient(QObject):
             self._suppress_bytes += cmd0.encode('utf-8')
             self.shell.send(cmd0)
             time.sleep(0.01)
-            # 2) keep PS1 empty to avoid prompt prints during setup (suppress)
-            cmd_ps1_empty = ":; PS1=\n"
-            self._suppress_bytes += cmd_ps1_empty.encode('utf-8')
-            self.shell.send(cmd_ps1_empty)
-            time.sleep(0.01)
+            # 2) keep shell quiet; do not modify PS1 to avoid prompt redraws
             # 3) keyboard/erase and flow control (with echo still OFF)
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
             time.sleep(0.01)
@@ -143,10 +139,8 @@ class SSHClient(QObject):
             # 5) bash tweak (no output)
             self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi\n")
             time.sleep(0.01)
-            # 6) locale and prompt (no output)
+            # 6) locale only (no output). Do not change PS1 to avoid extra prompt lines
             self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1\n")
-            time.sleep(0.01)
-            self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1\n")
             time.sleep(0.01)
             # 7) clear current line, re-enable echo, then request exactly one new prompt
             try:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -19,7 +19,7 @@ class SSHClient(QObject):
         
     def connect(self, host, port=22, username=None, password=None, auth_method='password', key_filename=None, passphrase=None, allow_agent=True, look_for_keys=False):
         try:
-            self.output_received.emit("🔗 Connecting to server...")
+            # Show connecting status only in UI status label, not in terminal
             
             self.client = paramiko.SSHClient()
             self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -151,13 +151,13 @@ class SSHClient(QObject):
             # 3) line discipline (not echoed when echo off)
             self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
             time.sleep(0.01)
-            # 4) bash tweak
-            self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")
+            # 4) bash tweak (suppress echo if bash)
+            self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi\n")
             time.sleep(0.01)
             # 5) prompt and locale
-            self.shell.send("export PS1='[\\u@\\h \\w]\\$ '\n")
+            self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1; printf ''\n")
             time.sleep(0.01)
-            self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null\n")
+            self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1\n")
             time.sleep(0.01)
             # 6) re-enable echo
             self.shell.send("stty echo 2>/dev/null\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -118,6 +118,8 @@ class SSHClient(QObject):
         try:
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D 2>/dev/null\n")
+            # Ensure canonical mode with echo and CR to NL mapping
+            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
             # Disable bracketed paste to avoid \x1b[?2004h noise
             # Use bash builtins when available; ignore errors on other shells
             self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -55,7 +55,6 @@ class SSHClient(QObject):
             self.read_thread.start()
             
             self.connection_status.emit(True, f"✅ Connected to {host}:{port}")
-            self.output_received.emit(f"Welcome to {host}\n")
 
             # Configure remote environment: prompt and terminal behavior
             self.configure_remote_environment()
@@ -117,9 +116,9 @@ class SSHClient(QObject):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
-            self.shell.send("stty -ixon -ixoff intr ^C eof ^D 2>/dev/null\n")
-            # Ensure canonical mode with echo and CR to NL mapping
-            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
+            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null\n")
+            # Ensure canonical mode with echo and CR to NL mapping; set erase to DEL
+            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr erase ^? 2>/dev/null\n")
             # Disable bracketed paste to avoid \x1b[?2004h noise
             # Use bash builtins when available; ignore errors on other shells
             self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -133,11 +133,6 @@ class SSHClient(QObject):
             cmd_ps1_empty = ":; PS1=\n"
             self._suppress_bytes += cmd_ps1_empty.encode('utf-8')
             self.shell.send(cmd_ps1_empty)
-            # Clear the currently printed default prompt line
-            try:
-                self.shell.send("\r\x1b[K")
-            except Exception:
-                pass
             time.sleep(0.01)
             # 3) keyboard/erase and flow control (with echo still OFF)
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
@@ -153,14 +148,8 @@ class SSHClient(QObject):
             time.sleep(0.01)
             self.shell.send("export PS1='[\\u@\\h \\w]\\$ ' >/dev/null 2>&1\n")
             time.sleep(0.01)
-            # 7) finally re-enable echo and force redraw of prompt once
+            # 7) finally re-enable echo (do not send extra CR/LF)
             self.shell.send("stty echo 2>/dev/null\n")
-            time.sleep(0.01)
-            try:
-                # Newline to make bash print the prompt with new PS1
-                self.shell.send("\r\n")
-            except Exception:
-                pass
         except Exception:
             pass
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -45,7 +45,8 @@ class SSHClient(QObject):
             
             self.is_connected = True
             # Allocate interactive PTY shell with colors
-            self.shell = self.client.invoke_shell(term='xterm-256color')
+            # Request a PTY with sane dimensions and xterm-256color
+            self.shell = self.client.invoke_shell(term='xterm-256color', width=160, height=40)
             self.shell.settimeout(0.0)
             
             # Start reading thread
@@ -110,7 +111,8 @@ class SSHClient(QObject):
             # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
             self.shell.send("stty -ixon -ixoff intr ^C eof ^D 2>/dev/null\n")
             # Disable bracketed paste to avoid \x1b[?2004h noise
-            self.shell.send("bind 'set enable-bracketed-paste off' 2>/dev/null\n")
+            # Use bash builtins when available; ignore errors on other shells
+            self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")
             # Set a simple, portable prompt. Works in bash/sh; \u,\h,\w are bash, but many servers use bash.
             # If not bash, this will be ignored harmlessly.
             self.shell.send("export PS1='[\\u@\\h \\w]\\$ '\n")

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -144,7 +144,7 @@ class SSHClient(QObject):
             self.shell.send(cmd1)
             time.sleep(0.01)
             # 2) keep PS1 empty to avoid prompt prints during setup
-            cmd2 = "PS1=\n"
+            cmd2 = ":; PS1=\n"
             self._suppress_bytes += cmd2.encode('utf-8')
             self.shell.send(cmd2)
             time.sleep(0.01)

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -56,13 +56,8 @@ class SSHClient(QObject):
             
             self.connection_status.emit(True, f"✅ Connected to {host}:{port}")
 
-            # Configure remote environment: prompt and terminal behavior
+            # Configure remote environment silently (suppress echo while setting)
             self.configure_remote_environment()
-            # Advertise UTF-8
-            try:
-                self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null\n")
-            except Exception:
-                pass
             
         except paramiko.AuthenticationException:
             error_msg = "❌ Authentication failed. Please check credentials."
@@ -115,17 +110,14 @@ class SSHClient(QObject):
     def configure_remote_environment(self):
         """Set prompt to [user@host cwd]$ and enable sane terminal controls."""
         try:
-            # Disable XON/XOFF so Ctrl+S/Ctrl+Q do not freeze terminal; set Ctrl-C/D
-            # Ensure canonical mode and echo; prefer ERASE=^H for compatibility
-            # Prefer ERASE=^? (DEL); if не поддерживается, bash всё равно примет Ctrl+H из UI
-            self.shell.send("stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null\n")
-            self.shell.send("stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null\n")
-            # Disable bracketed paste to avoid \x1b[?2004h noise
-            # Use bash builtins when available; ignore errors on other shells
-            self.shell.send("if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null\n")
-            # Set a simple, portable prompt. Works in bash/sh; \u,\h,\w are bash, but many servers use bash.
-            # If not bash, this will be ignored harmlessly.
-            self.shell.send("export PS1='[\\u@\\h \\w]\\$ '\n")
+            self.shell.send(
+                "stty -echo 2>/dev/null; "
+                "stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null; "
+                "stty echo icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
+                "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off'; fi 2>/dev/null; "
+                "export PS1='[\\u@\\h \\w]\\$ '; export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null; "
+                "stty echo 2>/dev/null\n"
+            )
         except Exception:
             pass
     

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -59,6 +59,11 @@ class SSHClient(QObject):
 
             # Configure remote environment: prompt and terminal behavior
             self.configure_remote_environment()
+            # Advertise UTF-8
+            try:
+                self.shell.send("export LANG=C.UTF-8 LC_ALL=C.UTF-8 2>/dev/null\n")
+            except Exception:
+                pass
             
         except paramiko.AuthenticationException:
             error_msg = "❌ Authentication failed. Please check credentials."

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -131,15 +131,13 @@ class SSHClient(QObject):
             time.sleep(0.02)
 
             # Then: run all settings with echo OFF, finally re-enable echo
+            # Do NOT touch PS1 or PROMPT_COMMAND to avoid extra prompts
             cmd = (
-                "OLD_PS1=\"$PS1\"; OLD_PC=\"$PROMPT_COMMAND\"; "
-                "PS1=; PROMPT_COMMAND=; "
                 "stty -ixon -ixoff intr ^C eof ^D erase ^? 2>/dev/null || stty erase ^H 2>/dev/null; "
                 "stty icanon icrnl -inlcr -igncr onlcr 2>/dev/null; "
                 "if [ -n \"$BASH_VERSION\" ]; then bind 'set enable-bracketed-paste off' >/dev/null 2>&1; fi; "
                 "export LANG=C.UTF-8 LC_ALL=C.UTF-8 >/dev/null 2>&1; "
-                "stty echo 2>/dev/null; "
-                "PS1=\"$OLD_PS1\"; PROMPT_COMMAND=\"$OLD_PC\"\n"
+                "stty echo 2>/dev/null\n"
             )
             self.shell.send(cmd)
         except Exception:

--- a/mobaxterm/core/ssh_client.py
+++ b/mobaxterm/core/ssh_client.py
@@ -151,8 +151,7 @@ class SSHClient(QObject):
                 pass
             self.shell.send("stty echo 2>/dev/null\n")
             time.sleep(0.01)
-            # Ask shell to render one new prompt
-            self.shell.send("\n")
+            # Do not send extra newline; the shell will already be at prompt
         except Exception:
             pass
     

--- a/mobaxterm/ui/main_window.py
+++ b/mobaxterm/ui/main_window.py
@@ -49,6 +49,8 @@ class SSHThread(QThread):
             allow_agent=True,
             look_for_keys=True
         )
+        # Start event loop so queued signals (input_to_send) are processed in this thread
+        self.exec_()
 
 class MobaXtermClone(QMainWindow):
     def __init__(self):

--- a/mobaxterm/ui/main_window.py
+++ b/mobaxterm/ui/main_window.py
@@ -764,13 +764,7 @@ class MobaXtermClone(QMainWindow):
                 self.status_label.setText("Disconnected")
             
         self.connection_info.setText(message)
-        
-        # Добавляем сообщение в соответствующую вкладку
-        for i in range(self.terminal_tabs.count()):
-            tab = self.terminal_tabs.widget(i)
-            if hasattr(tab, 'session_index') and tab.session_index == session_index:
-                tab.append_output(message)
-                break
+        # Не печатаем статусные сообщения в терминал, только в статус-бар
     
     def close_terminal_tab(self, index):
         tab = self.terminal_tabs.widget(index)

--- a/mobaxterm/ui/main_window.py
+++ b/mobaxterm/ui/main_window.py
@@ -717,6 +717,9 @@ class MobaXtermClone(QMainWindow):
 
             # Provide terminal with a way to send raw keys to this SSH thread
             terminal_tab.set_key_sender(lambda data, t=ssh_thread: t.send_raw(data))
+
+            # If the user starts typing immediately, ensure input is enabled
+            terminal_tab.enable_input()
     
     def execute_command(self, session_index, command: str):
         if session_index in self.ssh_threads and command is not None:

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -240,18 +240,20 @@ class TerminalTab(QWidget):
             cursor = self.terminal_output.textCursor()
             cursor.movePosition(QTextCursor.End)
             self.terminal_output.setTextCursor(cursor)
-            # Collapse excessive blank prompt lines: if two consecutive empty
-            # lines before prompt token, trim to one. We only do a light pass.
+            # Aggressively collapse trailing empty lines to a single one
             try:
                 doc = self.terminal_output.document()
-                last_block = doc.lastBlock()
-                prev_block = last_block.previous()
-                prev_prev_block = prev_block.previous() if prev_block.isValid() else None
-                if prev_block.isValid() and prev_prev_block and prev_block.text().strip() == '' and prev_prev_block.text().strip() == '':
-                    # remove one blank line
+                # Count trailing blank blocks
+                blanks = 0
+                blk = doc.lastBlock()
+                while blk.isValid() and blk.text().strip() == '':
+                    blanks += 1
+                    blk = blk.previous()
+                if blanks > 1:
                     c = self.terminal_output.textCursor()
                     c.movePosition(QTextCursor.End)
-                    c.movePosition(QTextCursor.PreviousBlock, QTextCursor.KeepAnchor)
+                    for _ in range(blanks - 1):
+                        c.movePosition(QTextCursor.PreviousBlock, QTextCursor.KeepAnchor)
                     c.removeSelectedText()
             except Exception:
                 pass

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -99,9 +99,8 @@ class TerminalTab(QWidget):
                 col0 = max(0, min(self._pyte_screen.cursor.x, len(line_text)))
                 cursor = self.terminal_output.textCursor()
                 cursor.movePosition(QTextCursor.Start)
-                # Move an extra line down to compensate initial off-by-one
-                # (moving down at the last line is a no-op in QTextCursor)
-                for _ in range(row0 + 1):
+                # Move to the correct row (0-based)
+                for _ in range(row0):
                     cursor.movePosition(QTextCursor.Down)
                 cursor.movePosition(QTextCursor.StartOfLine)
                 for _ in range(col0):

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -104,7 +104,7 @@ class TerminalTab(QWidget):
                         while len(tail_lines) >= 3 and tail_lines[-1].strip() == '' and tail_lines[-2].strip() == '':
                             tail_lines.pop()
                         # Deduplicate identical prompt lines at the very end
-                        prompt_re = re.compile(r"(^.+@.+:.*[#$]\s$|^\[[^\n]*\][#$]\s$)")
+                        prompt_re = re.compile(r"(^.+@.+:.*[#$]\s*$|^\[[^\n]*\][#$]\s*$)")
                         # Keep removing duplicates among last lines
                         changed = True
                         while changed and len(tail_lines) >= 2:

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -113,18 +113,17 @@ class TerminalTab(QWidget):
                                     col = 1
                                 self._line_cursor = max(0, min(len(self._line_buffer), col - 1))
                                 self._render_current_line()
-                            elif cmd == 'K':  # erase in line
-                                # Reset the editable line on K with mode 2 or when just after CR
+                            elif cmd == 'K':  # erase in line (default: to end)
+                                # Default to end-of-line when params empty
                                 mode = params if params else '0'
-                                if mode == '2' or self._in_prompt:
-                                    self._line_buffer = ''
-                                    self._line_cursor = 0
-                                elif mode == '0':  # to end
+                                if mode == '0':
                                     self._line_buffer = self._line_buffer[:self._line_cursor]
-                                elif mode == '1':  # to start
+                                elif mode == '1':
                                     self._line_buffer = self._line_buffer[self._line_cursor:]
                                     self._line_cursor = 0
-                                self._in_prompt = False
+                                elif mode == '2':
+                                    self._line_buffer = ''
+                                    self._line_cursor = 0
                                 self._render_current_line()
                             # ignore others
                             i += 1
@@ -153,10 +152,9 @@ class TerminalTab(QWidget):
                 continue
             # CR / LF handling
             if ch == '\r':
-                # Begin a fresh editable line repaint (readline typically emits CR before redrawing)
-                self._line_buffer = ''
+                # Move to line start
                 self._line_cursor = 0
-                self._in_prompt = True
+                self._render_current_line()
                 i += 1
                 continue
             if ch == '\n':

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -106,6 +106,13 @@ class TerminalTab(QWidget):
                             elif cmd == 'C':  # cursor right
                                 self._line_cursor = min(len(self._line_buffer), self._line_cursor + 1)
                                 self._render_current_line()
+                            elif cmd == 'G':  # CHA – cursor horizontal absolute
+                                try:
+                                    col = int(params) if params.isdigit() else 1
+                                except Exception:
+                                    col = 1
+                                self._line_cursor = max(0, min(len(self._line_buffer), col - 1))
+                                self._render_current_line()
                             elif cmd == 'K':  # erase to end of line
                                 self._line_buffer = self._line_buffer[:self._line_cursor]
                                 self._render_current_line()
@@ -160,10 +167,12 @@ class TerminalTab(QWidget):
             self._line_cursor += 1
             self._render_current_line()
             i += 1
-        # Auto-scroll to bottom
-        cursor = self.terminal_output.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        self.terminal_output.setTextCursor(cursor)
+        # Auto-scroll to bottom only when a newline is printed; otherwise
+        # keep caret where server editing logic placed it
+        if '\n' in text:
+            cursor = self.terminal_output.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            self.terminal_output.setTextCursor(cursor)
 
     def _write(self, text: str):
         cursor = self.terminal_output.textCursor()

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -41,7 +41,8 @@ class TerminalTab(QWidget):
         self.input_enabled = False
         self.current_input = ""
         self.prompt_text = "$ "
-        self.local_echo_enabled = True
+        # Local echo is off by default; remote shell echoes characters
+        self.local_echo_enabled = False
         
         # Only the terminal area is shown; input happens inline
         layout.addWidget(self.terminal_output)
@@ -118,11 +119,8 @@ class TerminalTab(QWidget):
                 return True
             # Enter / Return
             if key in (Qt.Key_Return, Qt.Key_Enter):
-                if self.local_echo_enabled:
-                    self._write("\n")
-                # Send both CR and LF to maximize compatibility
+                # Most PTYs expect CR; bash will map CR to NL via icrnl
                 self._send("\r")
-                self._send("\n")
                 return True
             # Backspace
             if key == Qt.Key_Backspace:

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -226,6 +226,21 @@ class TerminalTab(QWidget):
             cursor = self.terminal_output.textCursor()
             cursor.movePosition(QTextCursor.End)
             self.terminal_output.setTextCursor(cursor)
+            # Collapse excessive blank prompt lines: if two consecutive empty
+            # lines before prompt token, trim to one. We only do a light pass.
+            try:
+                doc = self.terminal_output.document()
+                last_block = doc.lastBlock()
+                prev_block = last_block.previous()
+                prev_prev_block = prev_block.previous() if prev_block.isValid() else None
+                if prev_block.isValid() and prev_prev_block and prev_block.text().strip() == '' and prev_prev_block.text().strip() == '':
+                    # remove one blank line
+                    c = self.terminal_output.textCursor()
+                    c.movePosition(QTextCursor.End)
+                    c.movePosition(QTextCursor.PreviousBlock, QTextCursor.KeepAnchor)
+                    c.removeSelectedText()
+            except Exception:
+                pass
 
     def _write(self, text: str):
         cursor = self.terminal_output.textCursor()

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -113,8 +113,17 @@ class TerminalTab(QWidget):
                                     col = 1
                                 self._line_cursor = max(0, min(len(self._line_buffer), col - 1))
                                 self._render_current_line()
-                            elif cmd == 'K':  # erase to end of line
-                                self._line_buffer = self._line_buffer[:self._line_cursor]
+                            elif cmd == 'K':  # erase in line
+                                # Interpret params (0: to end, 1: to start, 2: whole line)
+                                mode = params if params else '0'
+                                if mode == '0':  # to end
+                                    self._line_buffer = self._line_buffer[:self._line_cursor]
+                                elif mode == '1':  # to start
+                                    self._line_buffer = self._line_buffer[self._line_cursor:]
+                                    self._line_cursor = 0
+                                elif mode == '2':  # whole line
+                                    self._line_buffer = ''
+                                    self._line_cursor = 0
                                 self._render_current_line()
                             # ignore others
                             i += 1
@@ -143,7 +152,8 @@ class TerminalTab(QWidget):
                 continue
             # CR / LF handling
             if ch == '\r':
-                # Move to line start
+                # Start fresh render of the editable line (readline repaints on CR)
+                self._line_buffer = ''
                 self._line_cursor = 0
                 self._render_current_line()
                 i += 1

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -113,8 +113,17 @@ class TerminalTab(QWidget):
                                     col = 1
                                 self._line_cursor = max(0, min(len(self._line_buffer), col - 1))
                                 self._render_current_line()
-                            elif cmd == 'K':  # erase to end of line
-                                self._line_buffer = self._line_buffer[:self._line_cursor]
+                            elif cmd == 'K':  # erase in line (default: to end)
+                                # Default to end-of-line when params empty
+                                mode = params if params else '0'
+                                if mode == '0':
+                                    self._line_buffer = self._line_buffer[:self._line_cursor]
+                                elif mode == '1':
+                                    self._line_buffer = self._line_buffer[self._line_cursor:]
+                                    self._line_cursor = 0
+                                elif mode == '2':
+                                    self._line_buffer = ''
+                                    self._line_cursor = 0
                                 self._render_current_line()
                             # ignore others
                             i += 1

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -120,8 +120,9 @@ class TerminalTab(QWidget):
             if key in (Qt.Key_Return, Qt.Key_Enter):
                 if self.local_echo_enabled:
                     self._write("\n")
-                # Send CRLF to be safe with various ttys
-                self._send("\r\n")
+                # Send both CR and LF to maximize compatibility
+                self._send("\r")
+                self._send("\n")
                 return True
             # Backspace
             if key == Qt.Key_Backspace:

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -2,6 +2,10 @@ from PyQt5.QtWidgets import (QTabWidget, QWidget, QVBoxLayout, QTextEdit,
                              QHBoxLayout, QLineEdit, QLabel, QPushButton)
 from PyQt5.QtCore import Qt, pyqtSignal, QEvent
 from PyQt5.QtGui import QFont, QTextCursor
+try:
+    import pyte
+except Exception:
+    pyte = None
 import re
 
 class TerminalTab(QWidget):
@@ -49,10 +53,18 @@ class TerminalTab(QWidget):
         self.prompt_text = "$ "
         # Local echo is off by default; remote shell echoes characters
         self.local_echo_enabled = False
-        # Minimal line editor state for rendering interactive line updates
+        # Minimal line editor state (fallback only)
         self._line_buffer = ""
         self._line_cursor = 0
         self._in_prompt = True
+
+        # pyte screen/stream if available
+        self._pyte_screen = None
+        self._pyte_stream = None
+        if pyte is not None:
+            # Create a generous screen; resize is TODO
+            self._pyte_screen = pyte.Screen(160, 40)
+            self._pyte_stream = pyte.Stream(self._pyte_screen)
         
         # Only the terminal area is shown; input happens inline
         layout.addWidget(self.terminal_output)
@@ -69,7 +81,38 @@ class TerminalTab(QWidget):
         self.terminal_output.setReadOnly(True)
         
     def append_output(self, text):
-        # Minimal parser to handle interactive line editing sequences from bash/readline
+        # Preferred path: use pyte when available for correct terminal emulation
+        if self._pyte_stream is not None:
+            try:
+                self._pyte_stream.feed(text)
+                # Render entire screen to the QTextEdit
+                # Ensure number of lines equals screen height for consistent positioning
+                lines = list(self._pyte_screen.display)
+                height = getattr(self._pyte_screen, 'lines', len(lines))
+                if len(lines) < height:
+                    lines += [""] * (height - len(lines))
+                content = "\n".join(lines)
+                self.terminal_output.setPlainText(content)
+                # Compute caret by moving cursor to row/col (0-based)
+                row0 = max(0, min(self._pyte_screen.cursor.y, len(lines) - 1))
+                line_text = lines[row0] if 0 <= row0 < len(lines) else ""
+                col0 = max(0, min(self._pyte_screen.cursor.x, len(line_text)))
+                cursor = self.terminal_output.textCursor()
+                cursor.movePosition(QTextCursor.Start)
+                # Move an extra line down to compensate initial off-by-one
+                # (moving down at the last line is a no-op in QTextCursor)
+                for _ in range(row0 + 1):
+                    cursor.movePosition(QTextCursor.Down)
+                cursor.movePosition(QTextCursor.StartOfLine)
+                for _ in range(col0):
+                    cursor.movePosition(QTextCursor.Right)
+                self.terminal_output.setTextCursor(cursor)
+                return
+            except Exception:
+                # Fallback to minimal logic below
+                pass
+
+        # Fallback: minimal parser for line editing sequences
         i = 0
         while i < len(text):
             ch = text[i]

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -113,17 +113,8 @@ class TerminalTab(QWidget):
                                     col = 1
                                 self._line_cursor = max(0, min(len(self._line_buffer), col - 1))
                                 self._render_current_line()
-                            elif cmd == 'K':  # erase in line
-                                # Interpret params (0: to end, 1: to start, 2: whole line)
-                                mode = params if params else '0'
-                                if mode == '0':  # to end
-                                    self._line_buffer = self._line_buffer[:self._line_cursor]
-                                elif mode == '1':  # to start
-                                    self._line_buffer = self._line_buffer[self._line_cursor:]
-                                    self._line_cursor = 0
-                                elif mode == '2':  # whole line
-                                    self._line_buffer = ''
-                                    self._line_cursor = 0
+                            elif cmd == 'K':  # erase to end of line
+                                self._line_buffer = self._line_buffer[:self._line_cursor]
                                 self._render_current_line()
                             # ignore others
                             i += 1
@@ -152,8 +143,7 @@ class TerminalTab(QWidget):
                 continue
             # CR / LF handling
             if ch == '\r':
-                # Start fresh render of the editable line (readline repaints on CR)
-                self._line_buffer = ''
+                # Move to line start
                 self._line_cursor = 0
                 self._render_current_line()
                 i += 1

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -35,6 +35,8 @@ class TerminalTab(QWidget):
             }
         """)
         self.terminal_output.setPlainText("")
+        # Disable line wrap to keep rows aligned with emulator screen
+        self.terminal_output.setLineWrapMode(QTextEdit.NoWrap)
         self.terminal_output.installEventFilter(self)
         # Some key events are delivered to the viewport; filter there too
         self.terminal_output.viewport().installEventFilter(self)

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -52,6 +52,7 @@ class TerminalTab(QWidget):
         # Minimal line editor state for rendering interactive line updates
         self._line_buffer = ""
         self._line_cursor = 0
+        self._in_prompt = True
         
         # Only the terminal area is shown; input happens inline
         layout.addWidget(self.terminal_output)
@@ -146,9 +147,13 @@ class TerminalTab(QWidget):
                 self._write('\n')
                 self._line_buffer = ''
                 self._line_cursor = 0
+                self._in_prompt = True
                 i += 1
                 continue
             # Printable character
+            # Detect beginning of input after prompt paint
+            if self._in_prompt and ch not in (' ', '\t'):
+                self._in_prompt = False
             self._line_buffer = (
                 self._line_buffer[:self._line_cursor] + ch + self._line_buffer[self._line_cursor:]
             )
@@ -244,6 +249,7 @@ class TerminalTab(QWidget):
                 self._send("\x1b[C")
                 return True
             if key == Qt.Key_Left:
+                # Only send one left; do not perform any local deletion
                 self._send("\x1b[D")
                 return True
             if key == Qt.Key_Home:

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,9 @@ setup(
     name="mobaxtermbutbetter",
     version="0.1",
     packages=find_packages(),
+    install_requires=[
+        "paramiko",
+        "PyQt5",
+        "pyte>=0.8.1"
+    ],
 )


### PR DESCRIPTION
Implement remote shell prompt and keybinding handling directly within the terminal application.

This provides the desired `[username@server path]$` prompt and enables essential keybindings (Ctrl+C, Ctrl+D, Tab, etc.) by configuring the remote PTY and forwarding raw keypresses.

---
<a href="https://cursor.com/background-agent?bcId=bc-07c871cd-af0b-40d0-81d6-41ca936ec876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07c871cd-af0b-40d0-81d6-41ca936ec876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

