### PR TITLE
Add hover-activated exit icon to terminal

### DIFF
--- a/mobaxterm/ui/custom_tab_widget.py
+++ b/mobaxterm/ui/custom_tab_widget.py
@@ -17,14 +17,15 @@ class CloseButton(QPushButton):
                 font-weight: bold;
             }
             CloseButton:hover {
-                background-color: #ff4757; /* red square appears on hover */
-                color: white; /* cross becomes prominent */
+                background-color: rgba(255, 71, 87, 0.15); /* soft red square on hover */
+                color: #ff4757; /* cross becomes red */
                 border-radius: 3px;
-                border: 1px solid rgba(255, 71, 87, 0.65); /* subtle red highlight */
+                border: 1px solid rgba(255, 71, 87, 0.65); /* red outline */
             }
             CloseButton:pressed {
-                background-color: #e03a49;
-                border: 1px solid rgba(224, 58, 73, 0.75);
+                background-color: #ff4757; /* solid red when pressed */
+                color: white; /* white cross for contrast when pressed */
+                border: 1px solid rgba(224, 58, 73, 0.85);
             }
         """)
         self.setText("×")

--- a/mobaxterm/ui/custom_tab_widget.py
+++ b/mobaxterm/ui/custom_tab_widget.py
@@ -11,17 +11,20 @@ class CloseButton(QPushButton):
             CloseButton {
                 background-color: transparent;
                 border: none;
-                border-radius: 8px;
-                color: #666;
+                border-radius: 3px;
+                color: rgba(0, 0, 0, 0.35); /* faint cross by default */
                 font-size: 12px;
                 font-weight: bold;
             }
             CloseButton:hover {
-                background-color: #ff4757;
-                color: white;
+                background-color: #ff4757; /* red square appears on hover */
+                color: white; /* cross becomes prominent */
+                border-radius: 3px;
             }
         """)
         self.setText("×")
+        self.setCursor(Qt.PointingHandCursor)
+        self.setToolTip("Close")
 
 class CustomTabWidget(QTabWidget):
     tab_close_requested = pyqtSignal(int)

--- a/mobaxterm/ui/custom_tab_widget.py
+++ b/mobaxterm/ui/custom_tab_widget.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (QTabWidget, QWidget, QHBoxLayout, QLabel, 
-                             QPushButton, QStyle, QStyleOptionTab)
+                             QPushButton, QStyle, QStyleOptionTab, QGraphicsDropShadowEffect)
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QPainter
+from PyQt5.QtGui import QPainter, QColor
 
 class CloseButton(QPushButton):
     def __init__(self, parent=None):
@@ -25,6 +25,31 @@ class CloseButton(QPushButton):
         self.setText("×")
         self.setCursor(Qt.PointingHandCursor)
         self.setToolTip("Close")
+        # Prepare subtle red glow effect (disabled by default)
+        self._shadow = QGraphicsDropShadowEffect(self)
+        self._shadow.setBlurRadius(0)
+        self._shadow.setColor(QColor(255, 71, 87, 0))
+        self._shadow.setOffset(0, 0)
+        self.setGraphicsEffect(self._shadow)
+
+    def enterEvent(self, event):
+        # On hover: show a faint red glow around the square
+        try:
+            self._shadow.setBlurRadius(12)
+            self._shadow.setColor(QColor(255, 71, 87, 140))
+            self._shadow.setOffset(0, 0)
+        except Exception:
+            pass
+        return super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        # Remove glow when mouse leaves
+        try:
+            self._shadow.setBlurRadius(0)
+            self._shadow.setColor(QColor(255, 71, 87, 0))
+        except Exception:
+            pass
+        return super().leaveEvent(event)
 
 class CustomTabWidget(QTabWidget):
     tab_close_requested = pyqtSignal(int)

--- a/mobaxterm/ui/custom_tab_widget.py
+++ b/mobaxterm/ui/custom_tab_widget.py
@@ -20,6 +20,11 @@ class CloseButton(QPushButton):
                 background-color: #ff4757; /* red square appears on hover */
                 color: white; /* cross becomes prominent */
                 border-radius: 3px;
+                border: 1px solid rgba(255, 71, 87, 0.65); /* subtle red highlight */
+            }
+            CloseButton:pressed {
+                background-color: #e03a49;
+                border: 1px solid rgba(224, 58, 73, 0.75);
             }
         """)
         self.setText("×")

--- a/mobaxterm/ui/custom_tab_widget.py
+++ b/mobaxterm/ui/custom_tab_widget.py
@@ -8,7 +8,7 @@ class CloseButton(QPushButton):
         super().__init__(parent)
         self.setFixedSize(16, 16)
         self.setStyleSheet("""
-            CloseButton {
+            QPushButton {
                 background-color: transparent;
                 border: none;
                 border-radius: 3px;
@@ -16,13 +16,13 @@ class CloseButton(QPushButton):
                 font-size: 12px;
                 font-weight: bold;
             }
-            CloseButton:hover {
+            QPushButton:hover {
                 background-color: rgba(255, 71, 87, 0.15); /* soft red square on hover */
                 color: #ff4757; /* cross becomes red */
                 border-radius: 3px;
                 border: 1px solid rgba(255, 71, 87, 0.65); /* red outline */
             }
-            CloseButton:pressed {
+            QPushButton:pressed {
                 background-color: #ff4757; /* solid red when pressed */
                 color: white; /* white cross for contrast when pressed */
                 border: 1px solid rgba(224, 58, 73, 0.85);
@@ -31,6 +31,8 @@ class CloseButton(QPushButton):
         self.setText("×")
         self.setCursor(Qt.PointingHandCursor)
         self.setToolTip("Close")
+        # Ensure Qt tracks hover state for style engine
+        self.setAttribute(Qt.WA_Hover, True)
         # Prepare subtle red glow effect (disabled by default)
         self._shadow = QGraphicsDropShadowEffect(self)
         self._shadow.setBlurRadius(0)


### PR DESCRIPTION
Add a faint, always-visible close cross to terminal tabs that becomes prominent with a red square on hover to improve session close UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c7a0aa1-2e20-4f87-a48d-318397fd1eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c7a0aa1-2e20-4f87-a48d-318397fd1eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

