### PR TITLE
Implement dual-pane sftp terminal

### DIFF
--- a/mobaxterm/core/sftp_client.py
+++ b/mobaxterm/core/sftp_client.py
@@ -1,0 +1,126 @@
+import paramiko
+from PyQt5.QtCore import QObject, pyqtSignal
+import os
+import stat
+import time
+
+
+class SFTPClient(QObject):
+    connection_status = pyqtSignal(bool, str)
+    remote_listing = pyqtSignal(str, list)  # path, entries: [{name, is_dir, size, mtime, mode}]
+
+    def __init__(self):
+        super().__init__()
+        self.client = None
+        self.sftp = None
+        self.is_connected = False
+        self.current_path = None
+
+    def connect(self, host, port=22, username=None, password=None, auth_method='password', key_filename=None, passphrase=None, allow_agent=True, look_for_keys=True):
+        try:
+            self.client = paramiko.SSHClient()
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+            connect_kwargs = {
+                'hostname': host,
+                'port': port,
+                'username': username,
+                'timeout': 10,
+            }
+
+            if auth_method == 'key':
+                connect_kwargs['key_filename'] = key_filename
+                connect_kwargs['passphrase'] = passphrase
+                connect_kwargs['allow_agent'] = True if allow_agent is None else allow_agent
+                connect_kwargs['look_for_keys'] = True if look_for_keys is None else look_for_keys
+            else:
+                connect_kwargs['password'] = password
+                connect_kwargs['allow_agent'] = False
+                connect_kwargs['look_for_keys'] = False
+
+            self.client.connect(**connect_kwargs)
+            self.sftp = self.client.open_sftp()
+            # Determine initial directory
+            try:
+                self.current_path = self.sftp.normalize('.')
+            except Exception:
+                try:
+                    self.current_path = self.sftp.getcwd() or '/'
+                except Exception:
+                    self.current_path = '/'
+
+            self.is_connected = True
+            self.connection_status.emit(True, f"✅ SFTP connected to {host}:{port}")
+            # Emit first listing
+            self.list_dir(self.current_path)
+        except paramiko.AuthenticationException:
+            self.connection_status.emit(False, "❌ Authentication failed. Please check credentials.")
+        except paramiko.SSHException as e:
+            self.connection_status.emit(False, f"❌ SSH error: {str(e)}")
+        except Exception as e:
+            self.connection_status.emit(False, f"❌ SFTP connection error: {str(e)}")
+
+    def _format_entry(self, attr):
+        is_dir = stat.S_ISDIR(attr.st_mode)
+        return {
+            'name': getattr(attr, 'filename', ''),
+            'is_dir': is_dir,
+            'size': getattr(attr, 'st_size', 0),
+            'mtime': getattr(attr, 'st_mtime', 0),
+            'mode': getattr(attr, 'st_mode', 0),
+        }
+
+    def list_dir(self, path=None):
+        if not self.is_connected or self.sftp is None:
+            return
+        target = path or self.current_path or '/'
+        try:
+            attrs = self.sftp.listdir_attr(target)
+            entries = [self._format_entry(a) for a in attrs]
+            # Sort: dirs first, then files; both alphabetically
+            entries.sort(key=lambda e: (0 if e['is_dir'] else 1, e['name'].lower()))
+            self.remote_listing.emit(target, entries)
+        except Exception as e:
+            self.connection_status.emit(True, f"⚠️ Failed to list '{target}': {str(e)}")
+
+    def change_dir(self, new_path: str):
+        if not self.is_connected or self.sftp is None:
+            return
+        try:
+            # Normalize to absolute path
+            if not new_path:
+                new_path = self.current_path or '/'
+            if not new_path.startswith('/'):
+                base = self.current_path or '/'
+                candidate = os.path.normpath(os.path.join(base, new_path))
+            else:
+                candidate = os.path.normpath(new_path)
+
+            norm = self.sftp.normalize(candidate)
+            # Test access by listing
+            _ = self.sftp.listdir(norm)
+            self.current_path = norm
+            self.list_dir(norm)
+        except Exception as e:
+            self.connection_status.emit(True, f"⚠️ Cannot change directory: {str(e)}")
+
+    def up_dir(self):
+        if not self.current_path:
+            return
+        parent = os.path.dirname(self.current_path.rstrip('/')) or '/'
+        self.change_dir(parent)
+
+    def disconnect(self):
+        try:
+            if self.sftp:
+                self.sftp.close()
+        except Exception:
+            pass
+        try:
+            if self.client:
+                self.client.close()
+        except Exception:
+            pass
+        self.is_connected = False
+        self.connection_status.emit(False, "SFTP disconnected")
+

--- a/mobaxterm/ui/sftp_tab.py
+++ b/mobaxterm/ui/sftp_tab.py
@@ -1,0 +1,220 @@
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QSplitter,
+    QLineEdit, QPushButton, QTreeWidget, QTreeWidgetItem, QLabel
+)
+from PyQt5.QtCore import Qt, pyqtSignal
+import os
+import time
+
+
+class SFTPTab(QWidget):
+    # UI -> Thread
+    remote_change_dir = pyqtSignal(str)
+    remote_up_dir = pyqtSignal()
+
+    def __init__(self, session, parent=None):
+        super().__init__(parent)
+        self.session = session
+        self.session_index = None
+        self._remote_path = '/'
+        self._local_path = os.path.expanduser('~')
+        self.initUI()
+
+    def initUI(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        splitter = QSplitter(Qt.Horizontal)
+
+        # Left (Local) panel
+        left_panel = QWidget()
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.setSpacing(4)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+
+        left_top = QWidget()
+        left_top_layout = QHBoxLayout(left_top)
+        left_top_layout.setSpacing(6)
+        left_top_layout.setContentsMargins(6, 6, 6, 6)
+        left_label = QLabel("Local:")
+        self.local_up_btn = QPushButton("↑")
+        self.local_path_edit = QLineEdit(self._local_path)
+        left_top_layout.addWidget(left_label)
+        left_top_layout.addWidget(self.local_up_btn)
+        left_top_layout.addWidget(self.local_path_edit, 1)
+
+        self.local_tree = QTreeWidget()
+        self.local_tree.setHeaderLabels(["Name", "Size", "Modified"])
+        self.local_tree.setColumnWidth(0, 280)
+        self.local_tree.setAlternatingRowColors(True)
+
+        left_layout.addWidget(left_top)
+        left_layout.addWidget(self.local_tree)
+
+        # Right (Remote) panel
+        right_panel = QWidget()
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setSpacing(4)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        right_top = QWidget()
+        right_top_layout = QHBoxLayout(right_top)
+        right_top_layout.setSpacing(6)
+        right_top_layout.setContentsMargins(6, 6, 6, 6)
+        right_label = QLabel("Remote:")
+        self.remote_up_btn = QPushButton("↑")
+        self.remote_path_edit = QLineEdit(self._remote_path)
+        right_top_layout.addWidget(right_label)
+        right_top_layout.addWidget(self.remote_up_btn)
+        right_top_layout.addWidget(self.remote_path_edit, 1)
+
+        self.remote_tree = QTreeWidget()
+        self.remote_tree.setHeaderLabels(["Name", "Size", "Modified"])
+        self.remote_tree.setColumnWidth(0, 280)
+        self.remote_tree.setAlternatingRowColors(True)
+
+        right_layout.addWidget(right_top)
+        right_layout.addWidget(self.remote_tree)
+
+        splitter.addWidget(left_panel)
+        splitter.addWidget(right_panel)
+        splitter.setSizes([600, 600])
+
+        layout.addWidget(splitter)
+
+        # Wire local events
+        self.local_up_btn.clicked.connect(self.on_local_up)
+        self.local_path_edit.returnPressed.connect(self.on_local_path_enter)
+        self.local_tree.itemDoubleClicked.connect(self.on_local_item_double_clicked)
+
+        # Wire remote events
+        self.remote_up_btn.clicked.connect(lambda: self.remote_up_dir.emit())
+        self.remote_path_edit.returnPressed.connect(self.on_remote_path_enter)
+        self.remote_tree.itemDoubleClicked.connect(self.on_remote_item_double_clicked)
+
+        # Initial local listing
+        self._populate_local()
+
+    # ===== Local side =====
+    def _list_local(self, path):
+        try:
+            names = os.listdir(path)
+        except Exception:
+            return []
+        entries = []
+        for name in names:
+            full = os.path.join(path, name)
+            try:
+                st = os.stat(full)
+                is_dir = os.path.isdir(full)
+                entries.append({
+                    'name': name,
+                    'is_dir': is_dir,
+                    'size': st.st_size,
+                    'mtime': st.st_mtime,
+                })
+            except Exception:
+                continue
+        entries.sort(key=lambda e: (0 if e['is_dir'] else 1, e['name'].lower()))
+        return entries
+
+    def _fmt_size(self, size):
+        try:
+            for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+                if size < 1024:
+                    return f"{size:.0f} {unit}"
+                size /= 1024.0
+            return f"{size:.0f} PB"
+        except Exception:
+            return ""
+
+    def _fmt_time(self, ts):
+        try:
+            return time.strftime('%Y-%m-%d %H:%M', time.localtime(ts))
+        except Exception:
+            return ""
+
+    def _populate_local(self):
+        self.local_tree.clear()
+        self.local_path_edit.setText(self._local_path)
+        entries = self._list_local(self._local_path)
+        # Add parent dir entry ..
+        if self._local_path not in ('/', ''):
+            up_item = QTreeWidgetItem(["..", "", ""])
+            up_item.setData(0, Qt.UserRole, {'name': '..', 'is_dir': True})
+            self.local_tree.addTopLevelItem(up_item)
+        for e in entries:
+            name = ("📁 " if e['is_dir'] else "📄 ") + e['name']
+            size = "" if e['is_dir'] else self._fmt_size(e['size'])
+            mtime = self._fmt_time(e['mtime'])
+            it = QTreeWidgetItem([name, size, mtime])
+            it.setData(0, Qt.UserRole, e)
+            self.local_tree.addTopLevelItem(it)
+        self.local_tree.sortItems(0, Qt.AscendingOrder)
+
+    def on_local_up(self):
+        parent = os.path.dirname(self._local_path.rstrip(os.sep)) or os.sep
+        self._local_path = parent
+        self._populate_local()
+
+    def on_local_path_enter(self):
+        path = self.local_path_edit.text().strip()
+        if os.path.isdir(path):
+            self._local_path = path
+            self._populate_local()
+
+    def on_local_item_double_clicked(self, item, column):
+        data = item.data(0, Qt.UserRole)
+        if not data:
+            return
+        name = data.get('name')
+        is_dir = data.get('is_dir')
+        if name == '..':
+            self.on_local_up()
+            return
+        if is_dir:
+            self._local_path = os.path.join(self._local_path, name)
+            self._populate_local()
+
+    # ===== Remote side =====
+    def set_remote_listing(self, path, entries):
+        self._remote_path = path or '/'
+        self.remote_tree.clear()
+        self.remote_path_edit.setText(self._remote_path)
+        # Add parent dir entry .. when not at root
+        if self._remote_path not in ('/', ''):
+            up_item = QTreeWidgetItem(["..", "", ""])
+            up_item.setData(0, Qt.UserRole, {'name': '..', 'is_dir': True})
+            self.remote_tree.addTopLevelItem(up_item)
+        for e in entries or []:
+            name = ("📁 " if e.get('is_dir') else "📄 ") + e.get('name', '')
+            size = "" if e.get('is_dir') else self._fmt_size(e.get('size', 0))
+            mtime = self._fmt_time(e.get('mtime', 0))
+            it = QTreeWidgetItem([name, size, mtime])
+            it.setData(0, Qt.UserRole, e)
+            self.remote_tree.addTopLevelItem(it)
+        self.remote_tree.sortItems(0, Qt.AscendingOrder)
+
+    def on_remote_path_enter(self):
+        path = self.remote_path_edit.text().strip()
+        if path:
+            self.remote_change_dir.emit(path)
+
+    def on_remote_item_double_clicked(self, item, column):
+        data = item.data(0, Qt.UserRole)
+        if not data:
+            return
+        name = data.get('name')
+        is_dir = data.get('is_dir')
+        if name == '..':
+            self.remote_up_dir.emit()
+            return
+        if is_dir:
+            # Build new path relative to current
+            if self._remote_path.endswith('/'):
+                new_path = self._remote_path + name
+            else:
+                new_path = self._remote_path + '/' + name
+            self.remote_change_dir.emit(new_path)
+

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -452,6 +452,13 @@ class TerminalTabs(QTabWidget):
         # Add faint cross button that becomes prominent on hover with red square
         self._add_close_button_to_tab(tab_index)
         return tab
+
+    def add_sftp_tab(self, session, sftp_tab_widget: QWidget):
+        display_name = getattr(session, 'name', None) or session.host
+        tab_index = self.addTab(sftp_tab_widget, f"📁 {display_name}")
+        self.setCurrentIndex(tab_index)
+        self._add_close_button_to_tab(tab_index)
+        return sftp_tab_widget
         
     def get_current_terminal(self):
         current_widget = self.currentWidget()


### PR DESCRIPTION
Add SFTP connection support with a split-view file browser.

This enables users to browse and manage local and remote files side-by-side when connecting via SFTP sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-00fd5cee-4e54-4cf6-a112-2c45bd9634f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00fd5cee-4e54-4cf6-a112-2c45bd9634f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

