### PR TITLE
Set smaller ssh terminal font

### DIFF
--- a/mobaxterm/models/session.py
+++ b/mobaxterm/models/session.py
@@ -9,6 +9,7 @@ class Session:
     port: int
     name: Optional[str] = None
     username: Optional[str] = None
+    terminal_font_size: Optional[int] = None
     auth_method: str = "password"  # 'password' | 'key'
     private_key_path: Optional[str] = None
     private_key_passphrase: Optional[str] = None
@@ -34,6 +35,7 @@ class Session:
             'port': self.port,
             'name': self.name,
             'username': self.username,
+            'terminal_font_size': self.terminal_font_size,
 
             'auth_method': self.auth_method,
             'private_key_path': self.private_key_path,
@@ -52,6 +54,7 @@ class Session:
             port=data['port'],
             name=data.get('name'),
             username=data['username'],
+            terminal_font_size=data.get('terminal_font_size'),
             auth_method=data.get('auth_method', 'password'),
             private_key_path=data.get('private_key_path'),
             private_key_passphrase=data.get('private_key_passphrase'),

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -39,9 +39,12 @@ class TerminalTab(QWidget):
         default_font = QFont('Consolas')
         default_font.setStyleHint(QFont.Monospace)
         default_font.setFixedPitch(True)
-        # Use a slightly smaller initial font for SSH sessions
+        # Use session-configured font size when available; else SSH=12, others=14
         try:
-            base_point_size = 12 if getattr(self.session, 'type', None) == 'SSH' else 14
+            if getattr(self.session, 'terminal_font_size', None):
+                base_point_size = int(self.session.terminal_font_size)
+            else:
+                base_point_size = 12 if getattr(self.session, 'type', None) == 'SSH' else 14
         except Exception:
             base_point_size = 14
         default_font.setPointSize(base_point_size)

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -39,7 +39,12 @@ class TerminalTab(QWidget):
         default_font = QFont('Consolas')
         default_font.setStyleHint(QFont.Monospace)
         default_font.setFixedPitch(True)
-        default_font.setPointSize(14)
+        # Use a slightly smaller initial font for SSH sessions
+        try:
+            base_point_size = 12 if getattr(self.session, 'type', None) == 'SSH' else 14
+        except Exception:
+            base_point_size = 14
+        default_font.setPointSize(base_point_size)
         self.terminal_output.setFont(default_font)
         self.terminal_output.document().setDefaultFont(default_font)
         self._default_font = QFont(self.terminal_output.font())

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -397,105 +397,105 @@ class TerminalTab(QWidget):
                     return True
 
             if event.type() == QEvent.KeyPress:
-            # Handle zoom shortcuts regardless of input mode
-            key = event.key()
-            modifiers = event.modifiers()
-            if (modifiers & Qt.ControlModifier):
-                # Ctrl + : zoom in (requires Shift on many layouts)
-                if key == Qt.Key_Plus:
-                    self.terminal_output.zoomIn(1)
-                    self._zoom_steps += 1
+                # Handle zoom shortcuts regardless of input mode
+                key = event.key()
+                modifiers = event.modifiers()
+                if (modifiers & Qt.ControlModifier):
+                    # Ctrl + : zoom in (requires Shift on many layouts)
+                    if key == Qt.Key_Plus:
+                        self.terminal_output.zoomIn(1)
+                        self._zoom_steps += 1
+                        return True
+                    # Ctrl - : zoom out
+                    if key == Qt.Key_Minus:
+                        self.terminal_output.zoomOut(1)
+                        self._zoom_steps -= 1
+                        return True
+                    # Ctrl = : reset to default zoom
+                    if key == Qt.Key_Equal or key == Qt.Key_0:
+                        if self._zoom_steps > 0:
+                            self.terminal_output.zoomOut(self._zoom_steps)
+                        elif self._zoom_steps < 0:
+                            self.terminal_output.zoomIn(-self._zoom_steps)
+                        self._zoom_steps = 0
+                        return True
+                if not self.input_enabled:
+                    return True if self.terminal_output.isReadOnly() else False
+                # Ctrl+C
+                if (modifiers & Qt.ControlModifier) and key == Qt.Key_C:
+                    self._send("\x03")  # ETX
                     return True
-                # Ctrl - : zoom out
-                if key == Qt.Key_Minus:
-                    self.terminal_output.zoomOut(1)
-                    self._zoom_steps -= 1
+                # Ctrl+D
+                if (modifiers & Qt.ControlModifier) and key == Qt.Key_D:
+                    self._send("\x04")  # EOT
                     return True
-                # Ctrl = : reset to default zoom
-                if key == Qt.Key_Equal or key == Qt.Key_0:
-                    if self._zoom_steps > 0:
-                        self.terminal_output.zoomOut(self._zoom_steps)
-                    elif self._zoom_steps < 0:
-                        self.terminal_output.zoomIn(-self._zoom_steps)
-                    self._zoom_steps = 0
+                # Ctrl+S should not freeze: send XOFF only if we really want to; otherwise ignore
+                if (modifiers & Qt.ControlModifier) and key == Qt.Key_S:
+                    # ignore to prevent terminal freeze
                     return True
-            if not self.input_enabled:
-                return True if self.terminal_output.isReadOnly() else False
-            # Ctrl+C
-            if (modifiers & Qt.ControlModifier) and key == Qt.Key_C:
-                self._send("\x03")  # ETX
-                return True
-            # Ctrl+D
-            if (modifiers & Qt.ControlModifier) and key == Qt.Key_D:
-                self._send("\x04")  # EOT
-                return True
-            # Ctrl+S should not freeze: send XOFF only if we really want to; otherwise ignore
-            if (modifiers & Qt.ControlModifier) and key == Qt.Key_S:
-                # ignore to prevent terminal freeze
-                return True
-            # Enter / Return
-            if key in (Qt.Key_Return, Qt.Key_Enter):
-                # Most PTYs expect CR; bash will map CR to NL via icrnl
-                self._send("\r")
-                return True
-            # Backspace
-            if key == Qt.Key_Backspace:
-                # Send only DEL (erase = ^? per stty -a)
-                self._send("\x7f")
-                return True
-            # Tab completion
-            if key == Qt.Key_Tab:
-                # Ask for one completion attempt
-                self._send("\t")
-                return True
-            # Arrow keys and navigation as ANSI sequences
-            if key == Qt.Key_Up:
-                self._send("\x1b[A")
-                return True
-            if key == Qt.Key_Down:
-                self._send("\x1b[B")
-                return True
-            if key == Qt.Key_Right:
-                self._send("\x1b[C")
-                return True
-            if key == Qt.Key_Left:
-                # Only send one left; do not perform any local deletion
-                self._send("\x1b[D")
-                return True
-            if key == Qt.Key_Home:
-                self._send("\x1b[H")
-                return True
-            if key == Qt.Key_End:
-                self._send("\x1b[F")
-                return True
-            if key == Qt.Key_PageUp:
-                self._send("\x1b[5~")
-                return True
-            if key == Qt.Key_PageDown:
-                self._send("\x1b[6~")
-                return True
-            if key == Qt.Key_Delete:
-                self._send("\x1b[3~")
-                return True
-            # Ctrl+L clear screen
-            if (modifiers & Qt.ControlModifier) and key == Qt.Key_L:
-                self._send("\x0c")
-                return True
-            # Printable characters
-            text = event.text()
-            if text:
-                if self.local_echo_enabled:
-                    self._write(text)
-                self._send(text)
-                # Keep caret visually at the right side of input for SSH sessions
-                try:
-                    if getattr(self.session, 'type', None) == 'SSH':
-                        cursor = self.terminal_output.textCursor()
-                        cursor.movePosition(QTextCursor.End)
-                        self.terminal_output.setTextCursor(cursor)
-                except Exception:
-                    pass
-                return True
+                # Enter / Return
+                if key in (Qt.Key_Return, Qt.Key_Enter):
+                    # Most PTYs expect CR; bash will map CR to NL via icrnl
+                    self._send("\r")
+                    return True
+                # Backspace
+                if key == Qt.Key_Backspace:
+                    # Send only DEL (erase = ^? per stty -a)
+                    self._send("\x7f")
+                    return True
+                # Tab completion
+                if key == Qt.Key_Tab:
+                    # Ask for one completion attempt
+                    self._send("\t")
+                    return True
+                # Arrow keys and navigation as ANSI sequences
+                if key == Qt.Key_Up:
+                    self._send("\x1b[A")
+                    return True
+                if key == Qt.Key_Down:
+                    self._send("\x1b[B")
+                    return True
+                if key == Qt.Key_Right:
+                    self._send("\x1b[C")
+                    return True
+                if key == Qt.Key_Left:
+                    # Only send one left; do not perform any local deletion
+                    self._send("\x1b[D")
+                    return True
+                if key == Qt.Key_Home:
+                    self._send("\x1b[H")
+                    return True
+                if key == Qt.Key_End:
+                    self._send("\x1b[F")
+                    return True
+                if key == Qt.Key_PageUp:
+                    self._send("\x1b[5~")
+                    return True
+                if key == Qt.Key_PageDown:
+                    self._send("\x1b[6~")
+                    return True
+                if key == Qt.Key_Delete:
+                    self._send("\x1b[3~")
+                    return True
+                # Ctrl+L clear screen
+                if (modifiers & Qt.ControlModifier) and key == Qt.Key_L:
+                    self._send("\x0c")
+                    return True
+                # Printable characters
+                text = event.text()
+                if text:
+                    if self.local_echo_enabled:
+                        self._write(text)
+                    self._send(text)
+                    # Keep caret visually at the right side of input for SSH sessions
+                    try:
+                        if getattr(self.session, 'type', None) == 'SSH':
+                            cursor = self.terminal_output.textCursor()
+                            cursor.movePosition(QTextCursor.End)
+                            self.terminal_output.setTextCursor(cursor)
+                    except Exception:
+                        pass
+                    return True
         return super().eventFilter(obj, event)
 
     def _strip_ansi(self, s: str) -> str:

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -473,6 +473,14 @@ class TerminalTab(QWidget):
                 if self.local_echo_enabled:
                     self._write(text)
                 self._send(text)
+                # Keep caret visually at the right side of input for SSH sessions
+                try:
+                    if getattr(self.session, 'type', None) == 'SSH':
+                        cursor = self.terminal_output.textCursor()
+                        cursor.movePosition(QTextCursor.End)
+                        self.terminal_output.setTextCursor(cursor)
+                except Exception:
+                    pass
                 return True
         return super().eventFilter(obj, event)
 

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -521,6 +521,17 @@ class TerminalTab(QWidget):
                 key = event.key()
                 modifiers = event.modifiers()
                 if (modifiers & Qt.ControlModifier):
+                    # Paste with Ctrl+Shift+V
+                    if (modifiers & Qt.ShiftModifier) and key == Qt.Key_V:
+                        try:
+                            text = QApplication.clipboard().text()
+                            if text:
+                                if self.local_echo_enabled:
+                                    self._write(text)
+                                self._send(text)
+                        except Exception:
+                            pass
+                        return True
                     # Ctrl + : zoom in (requires Shift on many layouts)
                     if key == Qt.Key_Plus:
                         self.terminal_output.zoomIn(1)

--- a/mobaxterm/ui/terminal_tabs.py
+++ b/mobaxterm/ui/terminal_tabs.py
@@ -487,14 +487,6 @@ class TerminalTab(QWidget):
                     if self.local_echo_enabled:
                         self._write(text)
                     self._send(text)
-                    # Keep caret visually at the right side of input for SSH sessions
-                    try:
-                        if getattr(self.session, 'type', None) == 'SSH':
-                            cursor = self.terminal_output.textCursor()
-                            cursor.movePosition(QTextCursor.End)
-                            self.terminal_output.setTextCursor(cursor)
-                    except Exception:
-                        pass
                     return True
         return super().eventFilter(obj, event)
 


### PR DESCRIPTION
Set a smaller default font size for SSH terminal tabs to improve initial user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddbd2444-cb4f-4c5a-b358-97763b11eedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddbd2444-cb4f-4c5a-b358-97763b11eedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

