### PR TITLE
Улучшить компоновку терминала справа

### DIFF
--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="node_modules/@xterm/xterm/css/xterm.css" />
     <style>
+      html, body { height:100%; overflow:hidden; }
       body { margin:0; display:flex; height:100vh; font-family:sans-serif; }
       #left { width:320px; padding:12px; border-right:1px solid #ddd; box-sizing:border-box; }
       #right { flex:1; position:relative; overflow:hidden; }


### PR DESCRIPTION
Remove page-level scrolling to ensure the terminal fully occupies the right pane.

The previous layout caused a visible scrollbar that split the right pane, preventing the terminal from using the full available height. Disabling `overflow` on `html` and `body` resolves this by allowing the flexbox layout to correctly size the right pane and its terminal content.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a5cdb70-214d-4500-912f-ef5abc0cf506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a5cdb70-214d-4500-912f-ef5abc0cf506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

