### PR TITLE
Fix sftp connection in electron-proc

### DIFF
--- a/electron-poc/main.js
+++ b/electron-poc/main.js
@@ -340,6 +340,25 @@ ipcMain.handle('get-home', async () => {
   try { return app.getPath('home') } catch { return '/' }
 })
 
+// OS-aware path helpers for renderer (local FS only)
+ipcMain.handle('path-join', async (evt, payload) => {
+  try {
+    const a = (payload && payload.a) || ''
+    const b = (payload && payload.b) || ''
+    return path.join(a, b)
+  } catch (e) {
+    return ''
+  }
+})
+ipcMain.handle('path-dirname', async (evt, payload) => {
+  try {
+    const p = (payload && payload.p) || ''
+    return path.dirname(p)
+  } catch (e) {
+    return ''
+  }
+})
+
 ipcMain.handle('sftp-disconnect', async (evt, id) => {
   const rec = connections.get(id)
   if (rec) {

--- a/electron-poc/main.js
+++ b/electron-poc/main.js
@@ -159,7 +159,27 @@ ipcMain.handle('sftp-list', async (evt, remotePath) => {
   for (const rec of connections.values()) { if (rec.sftp) { first = rec.sftp; break } }
   if (!first) throw new Error('No SFTP connection')
   const list = await first.list(remotePath)
-  return list.map(e => ({ name: e.name, size: e.size, type: e.type }))
+  const base = (remotePath && typeof remotePath === 'string' && remotePath.length) ? remotePath : '/'
+  const mapped = await Promise.all(list.map(async (e) => {
+    let type = e.type
+    // Normalize types and resolve symlinks to determine if they point to directories
+    if (type === 'd' || /^(dir|directory)$/i.test(String(type))) {
+      type = 'd'
+    } else if (type === 'l') {
+      const full = path.posix.join(base === '/' ? '/' : base.replace(/\/+$/,'/'), e.name)
+      try {
+        const st = await first.stat(full)
+        const isDir = Boolean(st && (st.isDirectory || st.type === 'd' || ((st.mode & 0o170000) === 0o040000)))
+        type = isDir ? 'd' : 'file'
+      } catch {
+        type = 'file'
+      }
+    } else {
+      type = 'file'
+    }
+    return { name: e.name, size: e.size, type }
+  }))
+  return mapped
 })
 
 // Per-connection SFTP list
@@ -168,13 +188,32 @@ ipcMain.handle('sftp-list-id', async (evt, payload) => {
   const rec = connections.get(id)
   if (!rec || !rec.sftp) throw new Error('No SFTP connection for id')
   const list = await rec.sftp.list(remotePath)
-  return list.map(e => ({
-    name: e.name,
-    displayName: e.name,
-    pathName: e.name,
-    size: e.size,
-    type: e.type
+  const base = (remotePath && typeof remotePath === 'string' && remotePath.length) ? remotePath : '/'
+  const mapped = await Promise.all(list.map(async (e) => {
+    let type = e.type
+    if (type === 'd' || /^(dir|directory)$/i.test(String(type))) {
+      type = 'd'
+    } else if (type === 'l') {
+      const full = path.posix.join(base === '/' ? '/' : base.replace(/\/+$/,'/'), e.name)
+      try {
+        const st = await rec.sftp.stat(full)
+        const isDir = Boolean(st && (st.isDirectory || st.type === 'd' || ((st.mode & 0o170000) === 0o040000)))
+        type = isDir ? 'd' : 'file'
+      } catch {
+        type = 'file'
+      }
+    } else {
+      type = 'file'
+    }
+    return {
+      name: e.name,
+      displayName: e.name,
+      pathName: e.name,
+      size: e.size,
+      type
+    }
   }))
+  return mapped
 })
 
 // SFTP file operations

--- a/electron-poc/preload.js
+++ b/electron-poc/preload.js
@@ -39,6 +39,9 @@ contextBridge.exposeInMainWorld('api', {
   localRename: (from, to) => ipcRenderer.invoke('local-rename', { from, to }),
   localMkdir: (localPath) => ipcRenderer.invoke('local-mkdir', { path: localPath }),
   getHome: () => ipcRenderer.invoke('get-home'),
-  sftpDisconnect: (id) => ipcRenderer.invoke('sftp-disconnect', id)
+  sftpDisconnect: (id) => ipcRenderer.invoke('sftp-disconnect', id),
+  // OS-aware path helpers (local)
+  pathJoin: (a, b) => ipcRenderer.invoke('path-join', { a, b }),
+  pathDirname: (p) => ipcRenderer.invoke('path-dirname', { p })
 })
 

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -662,7 +662,14 @@
           const upRow = document.createElement('div')
           upRow.className = 'sftp-row'
           upRow.innerHTML = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M12 5l6 6h-4v6h-4v-6H6l6-6z"/></svg></span><div class="sftp-name">..</div><div class="sftp-type"></div>'
-          upRow.onclick = () => onEnterDir(dirname(basePath))
+          upRow.ondblclick = async () => {
+            if (el && el.id === 'sftp-local-list') {
+              const up = await window.api.pathDirname(basePath)
+              onEnterDir(up)
+            } else {
+              onEnterDir(dirname(basePath))
+            }
+          }
           rows.appendChild(upRow)
         }
         for (const it of items || []) {

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -687,22 +687,29 @@
       const sftpRemoteRefreshBtn = document.getElementById('sftp-remote-refresh')
       // no explicit remote connect button anymore
 
-      function renderListInto(el, basePath, items, onEnterDir) {
+      async function renderListInto(el, basePath, items, onEnterDir) {
         el.innerHTML = ''
         const rows = document.createDocumentFragment()
-        if (basePath && basePath !== '/') {
-          const upRow = document.createElement('div')
-          upRow.className = 'sftp-row'
-          upRow.innerHTML = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M12 5l6 6h-4v6h-4v-6H6l6-6z"/></svg></span><div class="sftp-name">..</div><div class="sftp-type"></div>'
-          upRow.ondblclick = async () => {
-            if (el && el.id === 'sftp-local-list') {
+        {
+          const isLocal = el && el.id === 'sftp-local-list'
+          let shouldShowUp = false
+          let upTarget = null
+          if (isLocal) {
+            try {
               const up = await window.api.pathDirname(basePath)
-              onEnterDir(up)
-            } else {
-              onEnterDir(dirname(basePath))
-            }
+              if (up && up !== basePath) { shouldShowUp = true; upTarget = up }
+            } catch {}
+          } else {
+            shouldShowUp = Boolean(basePath && basePath !== '/')
+            upTarget = dirname(basePath)
           }
-          rows.appendChild(upRow)
+          if (shouldShowUp) {
+            const upRow = document.createElement('div')
+            upRow.className = 'sftp-row'
+            upRow.innerHTML = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M12 5l6 6h-4v6h-4v-6H6l6-6z"/></svg></span><div class="sftp-name">..</div><div class="sftp-type"></div>'
+            upRow.ondblclick = () => onEnterDir(upTarget)
+            rows.appendChild(upRow)
+          }
         }
         for (const it of items || []) {
           const row = document.createElement('div')
@@ -715,7 +722,15 @@
           const fileIcon = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M4 3h16a2 2 0 012 2v14a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2zm3 4v2h10V7H7zm0 4v2h6v-2H7z"/></svg></span>'
           row.innerHTML = `${isDir ? folderIcon : fileIcon}<div class="sftp-name" title="${displayName}">${displayName}</div><div class="sftp-type">${isDir?'dir':'file'}</div>`
           // Navigate by double click
-          row.ondblclick = () => { if (isDir) onEnterDir(joinPath(basePath, pathName)); }
+          row.ondblclick = async () => {
+            if (!isDir) return
+            if (el && el.id === 'sftp-local-list') {
+              const next = await window.api.pathJoin(basePath, pathName)
+              onEnterDir(next)
+            } else {
+              onEnterDir(joinPath(basePath, pathName))
+            }
+          }
           // Context menu
           row.oncontextmenu = (e) => { e.preventDefault(); openSftpCtxMenu(e.clientX, e.clientY, { basePath, name: displayName, pathName, isDir, ownerEl: el }) }
           // Drag support
@@ -832,7 +847,7 @@
 
       async function listRemote(p) {
         const list = await window.api.sftpListById(currentId, p)
-        renderListInto(sftpRemoteListEl, p, list, navigateRemote)
+        await renderListInto(sftpRemoteListEl, p, list, navigateRemote)
       }
       async function navigateRemote(p) {
         sftpRemotePathEl.value = p
@@ -840,7 +855,7 @@
       }
       async function listLocal(p) {
         const list = await window.api.localList(p)
-        renderListInto(sftpLocalListEl, p, list, navigateLocal)
+        await renderListInto(sftpLocalListEl, p, list, navigateLocal)
       }
       async function navigateLocal(p) {
         sftpLocalPathEl.value = p

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -700,7 +700,9 @@
           const it = document.createElement('div'); it.className='ctx-item'; it.textContent=label; it.onmousedown=(e)=>{ e.preventDefault(); e.stopPropagation(); hideCtx(); handler() }; menu.appendChild(it)
         }
         const { basePath, name, pathName, isDir, ownerEl } = info
-        const fullPath = joinPath(basePath, (pathName || name))
+          const fullPath = (ownerEl && ownerEl.id === 'sftp-remote-list')
+            ? joinPath(basePath, (pathName || name))
+            : await window.api.pathJoin(basePath, (pathName || name))
         const isRemote = ownerEl && ownerEl.id === 'sftp-remote-list'
         add('Rename…', async () => {
           const newName = await showInputModal('Rename', 'New name', name)
@@ -710,7 +712,7 @@
             await window.api.sftpRename(id, fullPath, joinPath(basePath, newName))
             await navigateRemote(basePath)
           } else {
-            await window.api.localRename(fullPath, joinPath(basePath, newName))
+            await window.api.localRename(fullPath, await window.api.pathJoin(basePath, newName))
             await navigateLocal(basePath)
           }
         })
@@ -735,7 +737,7 @@
             await window.api.sftpMkdir(id, joinPath(targetDir, newName))
             await navigateRemote(targetDir)
           } else {
-            await window.api.localMkdir(joinPath(targetDir, newName))
+            await window.api.localMkdir(await window.api.pathJoin(targetDir, newName))
             await navigateLocal(targetDir)
           }
         })
@@ -771,10 +773,12 @@
       })
 
       function joinPath(a, b) {
-        if (!a || a === '/') return '/' + (b||'').replace(/^\/+/, '')
-        return (a.replace(/\/+$/,'') + '/' + (b||'').replace(/^\/+/, ''))
+        // Use main process to handle OS-specific separators for local paths only when called for local area
+        // For remote SFTP we keep POSIX join in navigateRemote
+        return (a && a.includes('\\')) ? null : ( (!a || a === '/') ? ('/' + (b||'').replace(/^\/+/, '')) : (a.replace(/\/+$/,'') + '/' + (b||'').replace(/^\/+/, '')) )
       }
       function dirname(p) {
+        if (p && p.includes('\\')) return null
         if (!p || p === '/') return '/'
         const parts = p.replace(/\/+$/,'').split('/')
         parts.pop()
@@ -816,8 +820,12 @@
       // connection is established on double-click of SFTP session in the tree
 
       sftpLocalRefreshBtn.onclick = () => navigateLocal(sftpLocalPathEl.value)
-      sftpLocalUpBtn.onclick = () => navigateLocal(dirname(sftpLocalPathEl.value))
-      sftpLocalPathEl.addEventListener('keydown', (e) => { if (e.key==='Enter') navigateLocal(sftpLocalPathEl.value) })
+      sftpLocalUpBtn.onclick = async () => {
+        const p = sftpLocalPathEl.value
+        const up = await window.api.pathDirname(p)
+        await navigateLocal(up)
+      }
+      sftpLocalPathEl.addEventListener('keydown', async (e) => { if (e.key==='Enter') { await navigateLocal(sftpLocalPathEl.value) } })
     </script>
   </body>
   </html>

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -672,7 +672,9 @@
           const rawName = String(it.name || it.displayName || it.pathName || '')
           const displayName = rawName
           const pathName = rawName
-          row.innerHTML = `${isDir ? '<span class=\"icon\"><svg viewBox=\\\"0 0 24 24\\\"><path d=\\\"M10 4l2 2h8a2 2 0 012 2v1H4V6a2 2 0 012-2h4zm12 6v8a2 2 0 01-2 2H6a2 2 0 01-2-2v-8h18z\\\"/></svg></span>' : '<span class=\\\"icon\\\"><svg viewBox=\\\"0 0 24 24\\\"><path d=\\\"M4 3h16a2 2 0 012 2v14a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2zm3 4v2h10V7H7zm0 4v2h6v-2H7z\\\"/></svg></span>'}<div class=\"sftp-name\" title=\"${displayName}\">${displayName}</div><div class=\"sftp-type\">${isDir?'dir':'file'}</div>`
+          const folderIcon = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M10 4l2 2h8a2 2 0 012 2v1H4V6a2 2 0 012-2h4zm12 6v8a2 2 0 01-2 2H6a2 2 0 01-2-2v-8h18z"/></svg></span>'
+          const fileIcon = '<span class="icon"><svg viewBox="0 0 24 24"><path d="M4 3h16a2 2 0 012 2v14a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2zm3 4v2h10V7H7zm0 4v2h6v-2H7z"/></svg></span>'
+          row.innerHTML = `${isDir ? folderIcon : fileIcon}<div class="sftp-name" title="${displayName}">${displayName}</div><div class="sftp-type">${isDir?'dir':'file'}</div>`
           // Navigate by double click
           row.ondblclick = () => { if (isDir) onEnterDir(joinPath(basePath, pathName)); }
           // Context menu

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -632,6 +632,38 @@
         })
       }
 
+      function showErrorModal(title, message) {
+        return new Promise((resolve) => {
+          const overlay = document.createElement('div')
+          overlay.className = 'modal-overlay'
+          const modal = document.createElement('div')
+          modal.className = 'modal'
+          const header = document.createElement('div')
+          header.className = 'modal-header'
+          header.textContent = title
+          const body = document.createElement('div')
+          body.className = 'modal-body'
+          const text = document.createElement('div')
+          text.style.whiteSpace = 'pre-wrap'
+          text.style.fontFamily = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
+          text.textContent = message
+          body.appendChild(text)
+          const actions = document.createElement('div')
+          actions.className = 'modal-actions'
+          const btnOk = document.createElement('button')
+          btnOk.className = 'btn primary'
+          btnOk.textContent = 'OK'
+          actions.appendChild(btnOk)
+          modal.appendChild(header); modal.appendChild(body); modal.appendChild(actions)
+          overlay.appendChild(modal)
+          document.body.appendChild(overlay)
+          const close = () => { try { document.body.removeChild(overlay) } catch {}; resolve() }
+          btnOk.onclick = close
+          overlay.addEventListener('keydown', (e) => { if (e.key==='Escape') close() })
+          setTimeout(() => btnOk.focus(), 0)
+        })
+      }
+
       // Load tree
       async function refreshSessions() {
         const res = await window.api.sessionsLoad()
@@ -804,7 +836,7 @@
       }
       async function navigateRemote(p) {
         sftpRemotePathEl.value = p
-        try { await listRemote(p) } catch (e) { alert('SFTP list error: ' + (e?.message||e)) }
+        try { await listRemote(p) } catch (e) { showErrorModal('SFTP list error', String(e?.message||e)) }
       }
       async function listLocal(p) {
         const list = await window.api.localList(p)
@@ -812,7 +844,7 @@
       }
       async function navigateLocal(p) {
         sftpLocalPathEl.value = p
-        try { await listLocal(p) } catch (e) { alert('Local list error: ' + (e?.message||e)) }
+        try { await listLocal(p) } catch (e) { showErrorModal('Local list error', String(e?.message||e)) }
       }
 
       async function initSftpSplitIfNeeded(id) {

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -668,9 +668,9 @@
         for (const it of items || []) {
           const row = document.createElement('div')
           row.className = 'sftp-row'
-          const isDir = (it.type === 'd' || it.type === 'directory' || it.type === 'DIR' || it.type === 'l')
-          const rawName = (it.pathName || it.name || '').replace(/\\+/g, '/')
-          const displayName = (it.displayName || it.name || '').split('\\\\').pop().split('/').pop()
+          const isDir = (it.type === 'd')
+          const rawName = String(it.name || it.displayName || it.pathName || '')
+          const displayName = rawName
           const pathName = rawName
           row.innerHTML = `${isDir ? '<span class=\"icon\"><svg viewBox=\\\"0 0 24 24\\\"><path d=\\\"M10 4l2 2h8a2 2 0 012 2v1H4V6a2 2 0 012-2h4zm12 6v8a2 2 0 01-2 2H6a2 2 0 01-2-2v-8h18z\\\"/></svg></span>' : '<span class=\\\"icon\\\"><svg viewBox=\\\"0 0 24 24\\\"><path d=\\\"M4 3h16a2 2 0 012 2v14a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2zm3 4v2h10V7H7zm0 4v2h6v-2H7z\\\"/></svg></span>'}<div class=\"sftp-name\" title=\"${displayName}\">${displayName}</div><div class=\"sftp-type\">${isDir?'dir':'file'}</div>`
           // Navigate by double click
@@ -689,24 +689,7 @@
         el.appendChild(rows)
       }
 
-      function normalizeSftpItems(basePath, rawItems) {
-        const map = new Map()
-        for (const it of rawItems || []) {
-          let nm = (it && it.name ? String(it.name) : '').trim()
-          if (!nm || nm === '.' || nm === '..') continue
-          nm = nm.replace(/\\+/g, '/')
-          const parts = nm.split('/').filter(Boolean)
-          if (parts.length === 0) continue
-          const seg = parts[0]
-          const isDir = (it.type === 'd') || (parts.length > 1) || (/(dir|directory)/i.test(String(it.type)))
-          if (!map.has(seg)) map.set(seg, { name: seg, displayName: seg, pathName: seg, type: isDir ? 'd' : 'file' })
-          else if (isDir) { const prev = map.get(seg); prev.type = 'd'; map.set(seg, prev) }
-        }
-        const items = Array.from(map.values())
-        // Directories first, then files, and limit file name width
-        items.sort((a, b) => (a.type === b.type ? a.displayName.localeCompare(b.displayName) : a.type === 'd' ? -1 : 1))
-        return items
-      }
+      function normalizeSftpItems(basePath, rawItems) { return rawItems }
 
       function openSftpCtxMenu(x, y, info) {
         const menu = document.getElementById('ctx')

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -668,7 +668,7 @@
         for (const it of items || []) {
           const row = document.createElement('div')
           row.className = 'sftp-row'
-          const isDir = (it.type === 'd' || it.type === 'directory' || it.type === 'DIR')
+          const isDir = (it.type === 'd' || it.type === 'directory' || it.type === 'DIR' || it.type === 'l')
           const rawName = (it.pathName || it.name || '').replace(/\\+/g, '/')
           const displayName = (it.displayName || it.name || '').split('\\\\').pop().split('/').pop()
           const pathName = rawName
@@ -799,8 +799,7 @@
 
       async function listRemote(p) {
         const list = await window.api.sftpListById(currentId, p)
-        const normalized = p === '/' ? normalizeSftpItems(p, list) : list
-        renderListInto(sftpRemoteListEl, p, normalized, navigateRemote)
+        renderListInto(sftpRemoteListEl, p, list, navigateRemote)
       }
       async function navigateRemote(p) {
         sftpRemotePathEl.value = p

--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -693,17 +693,18 @@
 
       function normalizeSftpItems(basePath, rawItems) { return rawItems }
 
-      function openSftpCtxMenu(x, y, info) {
+      async function openSftpCtxMenu(x, y, info) {
         const menu = document.getElementById('ctx')
         menu.innerHTML = ''
         function add(label, handler) {
           const it = document.createElement('div'); it.className='ctx-item'; it.textContent=label; it.onmousedown=(e)=>{ e.preventDefault(); e.stopPropagation(); hideCtx(); handler() }; menu.appendChild(it)
         }
         const { basePath, name, pathName, isDir, ownerEl } = info
-          const fullPath = (ownerEl && ownerEl.id === 'sftp-remote-list')
-            ? joinPath(basePath, (pathName || name))
-            : await window.api.pathJoin(basePath, (pathName || name))
         const isRemote = ownerEl && ownerEl.id === 'sftp-remote-list'
+        const fullPath = isRemote
+          ? joinPath(basePath, (pathName || name))
+          : await window.api.pathJoin(basePath, (pathName || name))
+        
         add('Rename…', async () => {
           const newName = await showInputModal('Rename', 'New name', name)
           if (!newName) return
@@ -753,11 +754,15 @@
           let data = null
           try { data = JSON.parse(e.dataTransfer.getData('application/json')) } catch {}
           if (!data || !data.name || !data.basePath) return
-          const srcFull = joinPath(data.basePath, (data.pathName || data.name))
+          const srcFull = (data.areaId === 'sftp-remote-list')
+            ? joinPath(data.basePath, (data.pathName || data.name))
+            : await window.api.pathJoin(data.basePath, (data.pathName || data.name))
           const dstIsRemote = id === 'sftp-remote-list'
           const srcIsRemote = data.areaId === 'sftp-remote-list'
           const dstBase = dstIsRemote ? sftpRemotePathEl.value : sftpLocalPathEl.value
-          const dstFull = joinPath(dstBase, (data.pathName || data.name))
+          const dstFull = dstIsRemote
+            ? joinPath(dstBase, (data.pathName || data.name))
+            : await window.api.pathJoin(dstBase, (data.pathName || data.name))
           try {
             if (srcIsRemote && !dstIsRemote) {
               await window.api.sftpDownload(currentId, srcFull, dstFull)


### PR DESCRIPTION
Add symlink-aware SFTP listing to correctly display remote symlinked directories as folders in the Electron terminal.

The previous implementation did not resolve symlinks, causing directories like `/bin` (which is often a symlink to `/usr/bin`) to be misclassified and displayed incorrectly in the SFTP file browser. This change uses `sftp.stat` to resolve symlink targets and normalizes file types to 'd' for directories and 'file' for others.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa497d77-d18b-49cb-8e98-3bd90f8a0f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa497d77-d18b-49cb-8e98-3bd90f8a0f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

