### PR TITLE
Clean up initial terminal connection output

### DIFF
--- a/electron-poc/renderer.html
+++ b/electron-poc/renderer.html
@@ -643,7 +643,7 @@
                     const rec = terminals.get(rid)
                     try { rec.fit.fit() } catch {}
                     try { window.api.sshResizeId(rid, rec.term.cols, rec.term.rows) } catch {}
-                    rec.term.write('\r\n[Connected]\r\n')
+                    // Removed explicit "[Connected]" banner and extra CRLF to avoid redundant line on first connect
                     showSshView()
                     activateTab(rid)
                   } catch (e) {


### PR DESCRIPTION
Remove explicit `[Connected]` message and extra line to prevent redundant output on initial terminal connection.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4b80682-55ab-4ac2-83c2-78ed4c0245a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4b80682-55ab-4ac2-83c2-78ed4c0245a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

